### PR TITLE
Update exception handling opcodes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
 <td>*catch</td>
 <td>*throw</td>
 <td>*rethrow</td>
-<td>*br_on_exn</td>
+<td></td>
 <td>end</td>
 <td>br</td>
 <td>br_if</td>
@@ -71,8 +71,8 @@
 <td>&nbsp;</td>
 <td>&nbsp;</td>
 <td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
+<td>*delegate</td>
+<td>*catch_all</td>
 <td>drop</td>
 <td>select</td>
 <td>*select t</td>


### PR DESCRIPTION
There is an update to [WebAssembly Exception Handling](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md#control-flow-operators) proposal.

The `br_on_exn` opcode is removed, `delegate` (0x18) and `catch_all` (0x19) has been added.